### PR TITLE
Feat/YB-92 유저 api 작성

### DIFF
--- a/src/main/java/com/example/yeobee/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/yeobee/common/config/RestTemplateConfig.java
@@ -1,11 +1,8 @@
 package com.example.yeobee.common.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -14,8 +11,6 @@ public class RestTemplateConfig {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplateBuilder()
-            .messageConverters(new MappingJackson2HttpMessageConverter(
-                new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)))
             .build();
     }
 }

--- a/src/main/java/com/example/yeobee/common/entity/BaseEntity.java
+++ b/src/main/java/com/example/yeobee/common/entity/BaseEntity.java
@@ -1,8 +1,7 @@
 package com.example.yeobee.common.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 import lombok.Getter;
@@ -15,10 +14,19 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseEntity {
 
-    @CreatedDate
     @Column(updatable = false)
     private ZonedDateTime createdAt;
-    
-    @LastModifiedDate
+
     private ZonedDateTime modifiedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = ZonedDateTime.now();
+        this.modifiedAt = ZonedDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.modifiedAt = ZonedDateTime.now();
+    }
 }

--- a/src/main/java/com/example/yeobee/common/entity/BaseEntity.java
+++ b/src/main/java/com/example/yeobee/common/entity/BaseEntity.java
@@ -1,12 +1,9 @@
 package com.example.yeobee.common.entity;
 
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter

--- a/src/main/java/com/example/yeobee/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/yeobee/common/exception/ErrorCode.java
@@ -26,8 +26,8 @@ public enum ErrorCode {
     /**
      * 3XXX -> User 에러
      */
-    USER_NOT_FOUND(2004, "User Not found", HttpStatus.NOT_FOUND);
-
+    USER_NOT_FOUND(3000, "User Not found", HttpStatus.NOT_FOUND),
+    AUTH_PROVIDER_NOT_FOUND(3001, "Auth Provider Not Found", HttpStatus.NOT_FOUND);
 
     private final int code;
     private final String message;

--- a/src/main/java/com/example/yeobee/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/yeobee/common/exception/ErrorCode.java
@@ -27,8 +27,8 @@ public enum ErrorCode {
      * 3XXX -> User 에러
      */
     USER_NOT_FOUND(3000, "User Not found", HttpStatus.NOT_FOUND),
-    AUTH_PROVIDER_NOT_FOUND(3001, "Auth Provider Not Found", HttpStatus.NOT_FOUND),
-    AUTH_PROVIDER_TYPE_INVALID(3002, "Auth Provider Type Is Invalid", HttpStatus.BAD_REQUEST);
+    AUTH_PROVIDER_NOT_FOUND(3001, "Auth Provider Not Found", HttpStatus.INTERNAL_SERVER_ERROR),
+    AUTH_PROVIDER_TYPE_INVALID(3002, "Auth Provider Type Is Invalid", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final int code;
     private final String message;

--- a/src/main/java/com/example/yeobee/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/yeobee/common/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
      * 3XXX -> User 에러
      */
     USER_NOT_FOUND(3000, "User Not found", HttpStatus.NOT_FOUND),
-    AUTH_PROVIDER_NOT_FOUND(3001, "Auth Provider Not Found", HttpStatus.NOT_FOUND);
+    AUTH_PROVIDER_NOT_FOUND(3001, "Auth Provider Not Found", HttpStatus.NOT_FOUND),
+    AUTH_PROVIDER_TYPE_INVALID(3002, "Auth Provider Type Is Invalid", HttpStatus.BAD_REQUEST);
 
     private final int code;
     private final String message;

--- a/src/main/java/com/example/yeobee/core/auth/application/AppleAuthService.java
+++ b/src/main/java/com/example/yeobee/core/auth/application/AppleAuthService.java
@@ -6,8 +6,6 @@ import com.example.yeobee.core.auth.domain.AuthProviderType;
 import com.example.yeobee.core.auth.dto.request.AppleLoginRequestDto;
 import com.example.yeobee.core.auth.dto.response.AppleAuthTokenResponseDto;
 import com.example.yeobee.core.auth.dto.response.TokenResponseDto;
-import com.example.yeobee.core.user.domain.User;
-import com.example.yeobee.core.user.domain.UserRepository;
 import com.example.yeobee.core.auth.util.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -41,20 +39,13 @@ public class AppleAuthService {
 
     private static final String OAUTH_ENDPOINT = "https://appleid.apple.com/auth/oauth2/v2/token";
 
-    private final UserRepository userRepository;
     private final AuthProviderRepository authProviderRepository;
     private final AuthService authService;
     private final AppleAuthProperties appleAuthProperties;
     private final RestTemplate restTemplate;
 
-    public void unlinkUser(User user) {
-        String appleRefreshToken = user.getAuthProviderList()
-            .stream()
-            .filter((e) -> e.getType() == AuthProviderType.APPLE)
-            .toList()
-            .get(0)
-            .getAppleRefreshToken();
-        userRepository.delete(user);
+    public void revoke(AuthProvider authProvider) {
+        String appleRefreshToken = authProvider.getAppleRefreshToken();
         String clientSecret = this.createClientSecret();
         String authUrl = "https://appleid.apple.com/auth/oauth2/v2/revoke";
 

--- a/src/main/java/com/example/yeobee/core/auth/application/AppleAuthService.java
+++ b/src/main/java/com/example/yeobee/core/auth/application/AppleAuthService.java
@@ -17,7 +17,6 @@ import lombok.SneakyThrows;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +35,7 @@ public class AppleAuthService {
     private static final String OAUTH_UNLINK_ENDPOINT = "https://appleid.apple.com/auth/oauth2/v2/revoke";
 
     private final AppleAuthProperties appleAuthProperties;
-    private final RestTemplate restTemplate = new RestTemplateBuilder().build();
+    private final RestTemplate restTemplate;
 
     public void revoke(AuthProvider authProvider) {
         String appleRefreshToken = authProvider.getAppleRefreshToken();

--- a/src/main/java/com/example/yeobee/core/auth/application/AppleAuthService.java
+++ b/src/main/java/com/example/yeobee/core/auth/application/AppleAuthService.java
@@ -1,12 +1,7 @@
 package com.example.yeobee.core.auth.application;
 
 import com.example.yeobee.core.auth.domain.AuthProvider;
-import com.example.yeobee.core.auth.domain.AuthProviderRepository;
-import com.example.yeobee.core.auth.domain.AuthProviderType;
-import com.example.yeobee.core.auth.dto.request.AppleLoginRequestDto;
 import com.example.yeobee.core.auth.dto.response.AppleAuthTokenResponseDto;
-import com.example.yeobee.core.auth.dto.response.TokenResponseDto;
-import com.example.yeobee.core.auth.util.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.io.Reader;
@@ -22,13 +17,13 @@ import lombok.SneakyThrows;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -37,17 +32,15 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class AppleAuthService {
 
-    private static final String OAUTH_ENDPOINT = "https://appleid.apple.com/auth/oauth2/v2/token";
+    private static final String OAUTH_TOKEN_ENDPOINT = "https://appleid.apple.com/auth/oauth2/v2/token";
+    private static final String OAUTH_UNLINK_ENDPOINT = "https://appleid.apple.com/auth/oauth2/v2/revoke";
 
-    private final AuthProviderRepository authProviderRepository;
-    private final AuthService authService;
     private final AppleAuthProperties appleAuthProperties;
-    private final RestTemplate restTemplate;
+    private final RestTemplate restTemplate = new RestTemplateBuilder().build();
 
     public void revoke(AuthProvider authProvider) {
         String appleRefreshToken = authProvider.getAppleRefreshToken();
         String clientSecret = this.createClientSecret();
-        String authUrl = "https://appleid.apple.com/auth/oauth2/v2/revoke";
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("client_id", appleAuthProperties.clientId());
@@ -59,32 +52,22 @@ public class AppleAuthService {
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(params, headers);
-        restTemplate.postForEntity(authUrl, httpEntity, AppleAuthTokenResponseDto.class);
+        restTemplate.postForEntity(OAUTH_UNLINK_ENDPOINT, httpEntity, AppleAuthTokenResponseDto.class);
     }
 
-    @Transactional
-    public TokenResponseDto login(AppleLoginRequestDto appleLoginRequest) {
-        String appleRefreshToken = requestAppleAuthToken(appleLoginRequest.code(),
-                                                         createClientSecret()).refreshToken();
-        String socialLoginId = JwtParser.getSocialIdFromJwt(appleLoginRequest.idToken());
-        AuthProvider authProvider = authService.login(socialLoginId, AuthProviderType.APPLE);
-        authProvider.setAppleRefreshToken(appleRefreshToken);
-        authProviderRepository.save(authProvider);
-        return authService.issueToken(authProvider.getUser());
-    }
-
-    private AppleAuthTokenResponseDto requestAppleAuthToken(String code, String client_secret) {
+    public AppleAuthTokenResponseDto requestAppleAuthToken(String code) {
+        String clientSecret = createClientSecret();
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("code", code);
         params.add("client_id", appleAuthProperties.clientId());
-        params.add("client_secret", client_secret);
+        params.add("client_secret", clientSecret);
         params.add("grant_type", "authorization_code");
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(params, headers);
-        ResponseEntity<AppleAuthTokenResponseDto> response = restTemplate.postForEntity(OAUTH_ENDPOINT,
+        ResponseEntity<AppleAuthTokenResponseDto> response = restTemplate.postForEntity(OAUTH_TOKEN_ENDPOINT,
                                                                                         httpEntity,
                                                                                         AppleAuthTokenResponseDto.class);
         return response.getBody();

--- a/src/main/java/com/example/yeobee/core/auth/application/AuthService.java
+++ b/src/main/java/com/example/yeobee/core/auth/application/AuthService.java
@@ -6,6 +6,7 @@ import com.example.yeobee.core.auth.domain.*;
 import com.example.yeobee.core.auth.dto.response.TokenResponseDto;
 import com.example.yeobee.core.user.domain.User;
 import com.example.yeobee.core.user.domain.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -46,7 +47,7 @@ public class AuthService {
         return authProvider;
     }
 
-    public void logout(User user){
+    public void logout(User user) {
         Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findById(user.getId());
         optionalRefreshToken.ifPresent(refreshTokenRepository::delete);
     }
@@ -64,5 +65,11 @@ public class AuthService {
         long userId = Long.parseLong(authToken.getClaims().getSubject());
         return userRepository.findById(userId)
             .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional
+    public void deleteUser(User user) {
+        authProviderRepository.delete(user.getAuthProvider());
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/com/example/yeobee/core/auth/application/AuthService.java
+++ b/src/main/java/com/example/yeobee/core/auth/application/AuthService.java
@@ -35,6 +35,7 @@ public class AuthService {
         return issueToken(authProvider.getUser());
     }
 
+    @Transactional
     public TokenResponseDto login(KakaoLoginRequestDto kakaoLoginRequest) {
         String socialLoginId = kakaoAuthService.getSocialLoginId(kakaoLoginRequest.oauthToken());
         AuthProvider authProvider = getOrCreateAuthProvider(socialLoginId, AuthProviderType.KAKAO);
@@ -55,8 +56,7 @@ public class AuthService {
         return new TokenResponseDto(newAuthToken.getToken(), refreshToken);
     }
 
-    @Transactional
-    public AuthProvider getOrCreateAuthProvider(String socialLoginId, AuthProviderType authProviderType) {
+    private AuthProvider getOrCreateAuthProvider(String socialLoginId, AuthProviderType authProviderType) {
         AuthProvider authProvider = authProviderRepository.findBySocialLoginId(socialLoginId)
             .orElse(new AuthProvider(socialLoginId, authProviderType));
 
@@ -73,7 +73,7 @@ public class AuthService {
         optionalRefreshToken.ifPresent(refreshTokenRepository::delete);
     }
 
-    public TokenResponseDto issueToken(User user) {
+    private TokenResponseDto issueToken(User user) {
         AuthToken refreshToken = tokenService.createRefreshToken(user.getId());
         AuthToken accessToken = tokenService.createAccessToken(user.getId());
         refreshTokenRepository.save(new RefreshToken(user.getId(), refreshToken.getToken()));

--- a/src/main/java/com/example/yeobee/core/auth/application/KakaoAuthProperties.java
+++ b/src/main/java/com/example/yeobee/core/auth/application/KakaoAuthProperties.java
@@ -1,0 +1,8 @@
+package com.example.yeobee.core.auth.application;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoAuthProperties(String adminKey) {
+
+}

--- a/src/main/java/com/example/yeobee/core/auth/application/KakaoAuthService.java
+++ b/src/main/java/com/example/yeobee/core/auth/application/KakaoAuthService.java
@@ -5,7 +5,6 @@ import com.example.yeobee.common.exception.ErrorCode;
 import com.example.yeobee.core.auth.domain.AuthProvider;
 import com.example.yeobee.core.auth.dto.response.KakaoUserResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -23,7 +22,7 @@ public class KakaoAuthService {
     private static final String OAUTH_UNLINK_ENDPOINT = "https://kapi.kakao.com/v1/user/unlink";
 
     private final KakaoAuthProperties kakaoAuthProperties;
-    private final RestTemplate restTemplate = new RestTemplateBuilder().build();
+    private final RestTemplate restTemplate;
 
     public String getSocialLoginId(String oauthToken) {
         try {

--- a/src/main/java/com/example/yeobee/core/auth/application/KakaoAuthService.java
+++ b/src/main/java/com/example/yeobee/core/auth/application/KakaoAuthService.java
@@ -70,8 +70,8 @@ public class KakaoAuthService {
 
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, headers);
 
-        ResponseEntity<String> response = restTemplate.exchange(
-            "https://kapi.kakao.com/v1/user/unlink",
+        restTemplate.exchange(
+            OAUTH_UNLINK_ENDPOINT,
             HttpMethod.POST,
             request,
             String.class);

--- a/src/main/java/com/example/yeobee/core/auth/dto/response/AppleAuthTokenResponseDto.java
+++ b/src/main/java/com/example/yeobee/core/auth/dto/response/AppleAuthTokenResponseDto.java
@@ -1,5 +1,7 @@
 package com.example.yeobee.core.auth.dto.response;
 
-public record AppleAuthTokenResponseDto(String accessToken, String refreshToken, String idToken) {
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AppleAuthTokenResponseDto(@JsonProperty("refresh_token") String refreshToken) {
 
 }

--- a/src/main/java/com/example/yeobee/core/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/yeobee/core/auth/presentation/AuthController.java
@@ -1,12 +1,7 @@
 package com.example.yeobee.core.auth.presentation;
 
-import com.example.yeobee.common.exception.BusinessException;
-import com.example.yeobee.common.exception.ErrorCode;
 import com.example.yeobee.core.auth.annotation.AuthUser;
-import com.example.yeobee.core.auth.application.AppleAuthService;
 import com.example.yeobee.core.auth.application.AuthService;
-import com.example.yeobee.core.auth.application.KakaoAuthService;
-import com.example.yeobee.core.auth.domain.AuthProvider;
 import com.example.yeobee.core.auth.dto.request.AppleLoginRequestDto;
 import com.example.yeobee.core.auth.dto.request.KakaoLoginRequestDto;
 import com.example.yeobee.core.auth.dto.response.TokenResponseDto;
@@ -21,8 +16,6 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
-    private final AppleAuthService appleAuthService;
-    private final KakaoAuthService kakaoAuthService;
 
     @GetMapping("/refresh")
     public ResponseEntity<TokenResponseDto> refreshToken(@RequestParam String refreshToken) {
@@ -31,13 +24,12 @@ public class AuthController {
 
     @PostMapping(value = "/login/apple")
     public ResponseEntity<TokenResponseDto> appleLogin(@RequestBody AppleLoginRequestDto appleLoginRequest) {
-        TokenResponseDto tokenResponseDto = appleAuthService.login(appleLoginRequest);
-        return ResponseEntity.ok(tokenResponseDto);
+        return ResponseEntity.ok(authService.login(appleLoginRequest));
     }
 
     @PostMapping(value = "/login/kakao")
     public ResponseEntity<TokenResponseDto> kakaoLogin(@RequestBody KakaoLoginRequestDto kakaoLoginRequest) {
-        return ResponseEntity.ok(kakaoAuthService.login(kakaoLoginRequest));
+        return ResponseEntity.ok(authService.login(kakaoLoginRequest));
     }
 
     @DeleteMapping(value = "/logout")
@@ -48,12 +40,6 @@ public class AuthController {
 
     @DeleteMapping(value = "/revoke")
     public ResponseEntity<Void> deleteUser(@AuthUser User user) {
-        AuthProvider authProvider = user.getAuthProvider();
-        switch (authProvider.getType()) {
-            case APPLE -> appleAuthService.revoke(authProvider);
-            case KAKAO -> kakaoAuthService.revoke(authProvider);
-            default -> throw new BusinessException(ErrorCode.AUTH_PROVIDER_TYPE_INVALID);
-        }
         authService.deleteUser(user);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/example/yeobee/core/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/yeobee/core/auth/presentation/AuthController.java
@@ -1,9 +1,12 @@
 package com.example.yeobee.core.auth.presentation;
 
+import com.example.yeobee.common.exception.BusinessException;
+import com.example.yeobee.common.exception.ErrorCode;
 import com.example.yeobee.core.auth.annotation.AuthUser;
 import com.example.yeobee.core.auth.application.AppleAuthService;
 import com.example.yeobee.core.auth.application.AuthService;
 import com.example.yeobee.core.auth.application.KakaoAuthService;
+import com.example.yeobee.core.auth.domain.AuthProvider;
 import com.example.yeobee.core.auth.dto.request.AppleLoginRequestDto;
 import com.example.yeobee.core.auth.dto.request.KakaoLoginRequestDto;
 import com.example.yeobee.core.auth.dto.response.TokenResponseDto;
@@ -38,8 +41,20 @@ public class AuthController {
     }
 
     @DeleteMapping(value = "/logout")
-    public ResponseEntity<Void> logout(@AuthUser User user){
+    public ResponseEntity<Void> logout(@AuthUser User user) {
         authService.logout(user);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping(value = "/revoke")
+    public ResponseEntity<Void> deleteUser(@AuthUser User user) {
+        AuthProvider authProvider = user.getAuthProvider();
+        switch (authProvider.getType()) {
+            case APPLE -> appleAuthService.revoke(authProvider);
+            case KAKAO -> kakaoAuthService.revoke(authProvider);
+            default -> throw new BusinessException(ErrorCode.AUTH_PROVIDER_TYPE_INVALID);
+        }
+        authService.deleteUser(user);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/yeobee/core/user/application/UserService.java
+++ b/src/main/java/com/example/yeobee/core/user/application/UserService.java
@@ -33,6 +33,7 @@ public class UserService {
         return new UserUpdateResponseDto(userRepository.save(user));
     }
 
+    @Transactional
     public void deleteUser(User user) {
         AuthProvider authProvider = user.getAuthProvider();
         switch (authProvider.getType()) {

--- a/src/main/java/com/example/yeobee/core/user/application/UserService.java
+++ b/src/main/java/com/example/yeobee/core/user/application/UserService.java
@@ -2,10 +2,12 @@ package com.example.yeobee.core.user.application;
 
 import com.example.yeobee.common.exception.BusinessException;
 import com.example.yeobee.common.exception.ErrorCode;
-import com.example.yeobee.core.auth.domain.AuthProviderType;
 import com.example.yeobee.core.user.domain.User;
 import com.example.yeobee.core.user.domain.UserRepository;
+import com.example.yeobee.core.user.dto.request.UserUpdateRequestDto;
 import com.example.yeobee.core.user.dto.response.UserInfoResponseDto;
+import com.example.yeobee.core.user.dto.response.UserUpdateResponseDto;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,8 +21,12 @@ public class UserService {
         if (user.getAuthProviderList().isEmpty()) {
             throw new BusinessException(ErrorCode.AUTH_PROVIDER_NOT_FOUND);
         }
-        return new UserInfoResponseDto(user.getNickname(),
-                                       user.getProfileImage(),
-                                       user.getAuthProviderList().get(0).getType());
+        return new UserInfoResponseDto(user);
+    }
+
+    @Transactional
+    public UserUpdateResponseDto updateUserInfo(User user, UserUpdateRequestDto request) {
+        user.updateInfo(request.nickname(), request.profileImageUrl());
+        return new UserUpdateResponseDto(user);
     }
 }

--- a/src/main/java/com/example/yeobee/core/user/application/UserService.java
+++ b/src/main/java/com/example/yeobee/core/user/application/UserService.java
@@ -30,7 +30,7 @@ public class UserService {
     @Transactional
     public UserUpdateResponseDto updateUserInfo(User user, UserUpdateRequestDto request) {
         user.updateInfo(request.nickname(), request.profileImageUrl());
-        return new UserUpdateResponseDto(userRepository.save(user));
+        return new UserUpdateResponseDto(user);
     }
 
     @Transactional

--- a/src/main/java/com/example/yeobee/core/user/application/UserService.java
+++ b/src/main/java/com/example/yeobee/core/user/application/UserService.java
@@ -34,16 +34,4 @@ public class UserService {
         user.updateInfo(request.nickname(), request.profileImageUrl());
         return new UserUpdateResponseDto(user);
     }
-
-    @Transactional
-    public void deleteUser(User user) {
-        AuthProvider authProvider = user.getAuthProvider();
-        switch (authProvider.getType()) {
-            case APPLE -> appleAuthService.revoke(authProvider);
-            case KAKAO -> kakaoAuthService.revoke(authProvider);
-            default -> throw new BusinessException(ErrorCode.AUTH_PROVIDER_TYPE_INVALID);
-        }
-        authProviderRepository.delete(authProvider);
-        userRepository.delete(user);
-    }
 }

--- a/src/main/java/com/example/yeobee/core/user/application/UserService.java
+++ b/src/main/java/com/example/yeobee/core/user/application/UserService.java
@@ -1,6 +1,11 @@
 package com.example.yeobee.core.user.application;
 
+import com.example.yeobee.common.exception.BusinessException;
+import com.example.yeobee.common.exception.ErrorCode;
+import com.example.yeobee.core.auth.domain.AuthProviderType;
+import com.example.yeobee.core.user.domain.User;
 import com.example.yeobee.core.user.domain.UserRepository;
+import com.example.yeobee.core.user.dto.response.UserInfoResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,4 +14,13 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+
+    public UserInfoResponseDto getUserInfo(User user) {
+        if (user.getAuthProviderList().isEmpty()) {
+            throw new BusinessException(ErrorCode.AUTH_PROVIDER_NOT_FOUND);
+        }
+        return new UserInfoResponseDto(user.getNickname(),
+                                       user.getProfileImage(),
+                                       user.getAuthProviderList().get(0).getType());
+    }
 }

--- a/src/main/java/com/example/yeobee/core/user/application/UserService.java
+++ b/src/main/java/com/example/yeobee/core/user/application/UserService.java
@@ -5,6 +5,7 @@ import com.example.yeobee.common.exception.ErrorCode;
 import com.example.yeobee.core.auth.application.AppleAuthService;
 import com.example.yeobee.core.auth.application.KakaoAuthService;
 import com.example.yeobee.core.auth.domain.AuthProvider;
+import com.example.yeobee.core.auth.domain.AuthProviderRepository;
 import com.example.yeobee.core.auth.domain.AuthProviderType;
 import com.example.yeobee.core.user.domain.User;
 import com.example.yeobee.core.user.domain.UserRepository;
@@ -22,6 +23,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final AppleAuthService appleAuthService;
     private final KakaoAuthService kakaoAuthService;
+    private final AuthProviderRepository authProviderRepository;
 
     public UserInfoResponseDto getUserInfo(User user) {
         return new UserInfoResponseDto(user);
@@ -41,6 +43,7 @@ public class UserService {
             case KAKAO -> kakaoAuthService.revoke(authProvider);
             default -> throw new BusinessException(ErrorCode.AUTH_PROVIDER_TYPE_INVALID);
         }
+        authProviderRepository.delete(authProvider);
         userRepository.delete(user);
     }
 }

--- a/src/main/java/com/example/yeobee/core/user/application/UserService.java
+++ b/src/main/java/com/example/yeobee/core/user/application/UserService.java
@@ -1,14 +1,6 @@
 package com.example.yeobee.core.user.application;
 
-import com.example.yeobee.common.exception.BusinessException;
-import com.example.yeobee.common.exception.ErrorCode;
-import com.example.yeobee.core.auth.application.AppleAuthService;
-import com.example.yeobee.core.auth.application.KakaoAuthService;
-import com.example.yeobee.core.auth.domain.AuthProvider;
-import com.example.yeobee.core.auth.domain.AuthProviderRepository;
-import com.example.yeobee.core.auth.domain.AuthProviderType;
 import com.example.yeobee.core.user.domain.User;
-import com.example.yeobee.core.user.domain.UserRepository;
 import com.example.yeobee.core.user.dto.request.UserUpdateRequestDto;
 import com.example.yeobee.core.user.dto.response.UserInfoResponseDto;
 import com.example.yeobee.core.user.dto.response.UserUpdateResponseDto;
@@ -19,11 +11,6 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UserService {
-
-    private final UserRepository userRepository;
-    private final AppleAuthService appleAuthService;
-    private final KakaoAuthService kakaoAuthService;
-    private final AuthProviderRepository authProviderRepository;
 
     public UserInfoResponseDto getUserInfo(User user) {
         return new UserInfoResponseDto(user);

--- a/src/main/java/com/example/yeobee/core/user/domain/User.java
+++ b/src/main/java/com/example/yeobee/core/user/domain/User.java
@@ -12,10 +12,15 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE shop SET isDeleted = true WHERE id = ?")
+@SQLRestriction("isDeleted = false")
 public class User extends BaseEntity {
 
     @Id
@@ -25,6 +30,8 @@ public class User extends BaseEntity {
     private String nickname;
 
     private String profileImageUrl;
+
+    private boolean isDeleted = Boolean.FALSE;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<AuthProvider> authProviderList = new ArrayList<>();

--- a/src/main/java/com/example/yeobee/core/user/domain/User.java
+++ b/src/main/java/com/example/yeobee/core/user/domain/User.java
@@ -21,7 +21,7 @@ public class User extends BaseEntity {
 
     private String nickname;
 
-    private String profileImage;
+    private String profileImageUrl;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<AuthProvider> authProviderList = new ArrayList<>();
@@ -38,5 +38,10 @@ public class User extends BaseEntity {
         if (authProvider.getUser() == null) {
             authProvider.setUser(this);
         }
+    }
+
+    public void updateInfo(String nickname, String profileImage) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImage;
     }
 }

--- a/src/main/java/com/example/yeobee/core/user/domain/User.java
+++ b/src/main/java/com/example/yeobee/core/user/domain/User.java
@@ -1,7 +1,10 @@
 package com.example.yeobee.core.user.domain;
 
 import com.example.yeobee.common.entity.BaseEntity;
+import com.example.yeobee.common.exception.BusinessException;
+import com.example.yeobee.common.exception.ErrorCode;
 import com.example.yeobee.core.auth.domain.AuthProvider;
+import com.example.yeobee.core.auth.domain.AuthProviderType;
 import com.example.yeobee.core.tripUser.domain.TripUser;
 import jakarta.persistence.*;
 import java.util.ArrayList;
@@ -43,5 +46,12 @@ public class User extends BaseEntity {
     public void updateInfo(String nickname, String profileImage) {
         this.nickname = nickname;
         this.profileImageUrl = profileImage;
+    }
+
+    public AuthProvider getAuthProvider() {
+        if (authProviderList.isEmpty()) {
+            throw new BusinessException(ErrorCode.AUTH_PROVIDER_NOT_FOUND);
+        }
+        return authProviderList.get(0);
     }
 }

--- a/src/main/java/com/example/yeobee/core/user/domain/User.java
+++ b/src/main/java/com/example/yeobee/core/user/domain/User.java
@@ -19,8 +19,8 @@ import org.hibernate.annotations.Where;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE shop SET isDeleted = true WHERE id = ?")
-@SQLRestriction("isDeleted = false")
+@SQLDelete(sql = "UPDATE user SET is_deleted = true WHERE id = ?")
+@SQLRestriction("is_deleted = false")
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/com/example/yeobee/core/user/domain/User.java
+++ b/src/main/java/com/example/yeobee/core/user/domain/User.java
@@ -31,7 +31,7 @@ public class User extends BaseEntity {
 
     private String profileImageUrl;
 
-    private boolean isDeleted = Boolean.FALSE;
+    private boolean isDeleted = false;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<AuthProvider> authProviderList = new ArrayList<>();

--- a/src/main/java/com/example/yeobee/core/user/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/com/example/yeobee/core/user/dto/request/UserUpdateRequestDto.java
@@ -1,0 +1,5 @@
+package com.example.yeobee.core.user.dto.request;
+
+public record UserUpdateRequestDto(String nickname, String profileImageUrl) {
+
+}

--- a/src/main/java/com/example/yeobee/core/user/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/example/yeobee/core/user/dto/response/UserInfoResponseDto.java
@@ -1,0 +1,6 @@
+package com.example.yeobee.core.user.dto.response;
+
+import com.example.yeobee.core.auth.domain.AuthProviderType;
+
+public record UserInfoResponseDto(String nickname, String profileImage, AuthProviderType authProviderType) {
+}

--- a/src/main/java/com/example/yeobee/core/user/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/example/yeobee/core/user/dto/response/UserInfoResponseDto.java
@@ -1,6 +1,11 @@
 package com.example.yeobee.core.user.dto.response;
 
 import com.example.yeobee.core.auth.domain.AuthProviderType;
+import com.example.yeobee.core.user.domain.User;
 
 public record UserInfoResponseDto(String nickname, String profileImage, AuthProviderType authProviderType) {
+
+    public UserInfoResponseDto(User user) {
+        this(user.getNickname(), user.getProfileImageUrl(), user.getAuthProviderList().get(0).getType());
+    }
 }

--- a/src/main/java/com/example/yeobee/core/user/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/example/yeobee/core/user/dto/response/UserInfoResponseDto.java
@@ -6,6 +6,6 @@ import com.example.yeobee.core.user.domain.User;
 public record UserInfoResponseDto(String nickname, String profileImage, AuthProviderType authProviderType) {
 
     public UserInfoResponseDto(User user) {
-        this(user.getNickname(), user.getProfileImageUrl(), user.getAuthProviderList().get(0).getType());
+        this(user.getNickname(), user.getProfileImageUrl(), user.getAuthProvider().getType());
     }
 }

--- a/src/main/java/com/example/yeobee/core/user/dto/response/UserUpdateResponseDto.java
+++ b/src/main/java/com/example/yeobee/core/user/dto/response/UserUpdateResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.yeobee.core.user.dto.response;
+
+import com.example.yeobee.core.user.domain.User;
+
+public record UserUpdateResponseDto(String nickname, String profileImageUrl) {
+
+    public UserUpdateResponseDto(User user) {
+        this(user.getNickname(), user.getProfileImageUrl());
+    }
+}

--- a/src/main/java/com/example/yeobee/core/user/presentation/UserController.java
+++ b/src/main/java/com/example/yeobee/core/user/presentation/UserController.java
@@ -3,12 +3,12 @@ package com.example.yeobee.core.user.presentation;
 import com.example.yeobee.core.auth.annotation.AuthUser;
 import com.example.yeobee.core.user.application.UserService;
 import com.example.yeobee.core.user.domain.User;
+import com.example.yeobee.core.user.dto.request.UserUpdateRequestDto;
 import com.example.yeobee.core.user.dto.response.UserInfoResponseDto;
+import com.example.yeobee.core.user.dto.response.UserUpdateResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +20,12 @@ public class UserController {
     @GetMapping(value = "/me")
     public ResponseEntity<UserInfoResponseDto> getUserInfo(@AuthUser User user) {
         return ResponseEntity.ok(userService.getUserInfo(user));
+    }
+
+    @PatchMapping(value = "/me")
+    public ResponseEntity<UserUpdateResponseDto> updateUserInfo(
+        @AuthUser User user,
+        @RequestBody UserUpdateRequestDto request) {
+        return ResponseEntity.ok(userService.updateUserInfo(user, request));
     }
 }

--- a/src/main/java/com/example/yeobee/core/user/presentation/UserController.java
+++ b/src/main/java/com/example/yeobee/core/user/presentation/UserController.java
@@ -28,10 +28,4 @@ public class UserController {
         @RequestBody UserUpdateRequestDto request) {
         return ResponseEntity.ok(userService.updateUserInfo(user, request));
     }
-
-    @DeleteMapping(value = "/me")
-    public ResponseEntity<Void> deleteUser(@AuthUser User user) {
-        userService.deleteUser(user);
-        return ResponseEntity.noContent().build();
-    }
 }

--- a/src/main/java/com/example/yeobee/core/user/presentation/UserController.java
+++ b/src/main/java/com/example/yeobee/core/user/presentation/UserController.java
@@ -28,4 +28,10 @@ public class UserController {
         @RequestBody UserUpdateRequestDto request) {
         return ResponseEntity.ok(userService.updateUserInfo(user, request));
     }
+
+    @DeleteMapping(value = "/me")
+    public ResponseEntity<Void> deleteUser(@AuthUser User user) {
+        userService.deleteUser(user);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/example/yeobee/core/user/presentation/UserController.java
+++ b/src/main/java/com/example/yeobee/core/user/presentation/UserController.java
@@ -1,0 +1,24 @@
+package com.example.yeobee.core.user.presentation;
+
+import com.example.yeobee.core.auth.annotation.AuthUser;
+import com.example.yeobee.core.user.application.UserService;
+import com.example.yeobee.core.user.domain.User;
+import com.example.yeobee.core.user.dto.response.UserInfoResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping(value = "/me")
+    public ResponseEntity<UserInfoResponseDto> getUserInfo(@AuthUser User user) {
+        return ResponseEntity.ok(userService.getUserInfo(user));
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,3 +32,5 @@ oauth:
     key-id: ${APPLE_KEY_ID}
     team-id: ${APPLE_TEAM_ID}
     client-id: ${APPLE_CLIENT_ID}
+  kakao:
+    admin-key: ${KAKAO_ADMIN_KEY}

--- a/src/main/resources/db/migration/V3__modifyUser.sql
+++ b/src/main/resources/db/migration/V3__modifyUser.sql
@@ -1,2 +1,4 @@
 alter table user
     change profile_image profile_image_url varchar(255);
+alter table user
+    add column is_deleted BOOLEAN;

--- a/src/main/resources/db/migration/V3__modifyUser.sql
+++ b/src/main/resources/db/migration/V3__modifyUser.sql
@@ -1,0 +1,2 @@
+alter table user
+    change profile_image profile_image_url varchar(255);

--- a/src/test/java/com/example/yeobee/config/MysqlTestContainer.java
+++ b/src/test/java/com/example/yeobee/config/MysqlTestContainer.java
@@ -8,7 +8,7 @@ import org.testcontainers.utility.DockerImageName;
 @Component
 public class MysqlTestContainer {
 
-    public static final String DATABASE_NAME = "ddip";
+    public static final String DATABASE_NAME = "yeobee";
     public static final String USERNAME = "root";
     public static final String PASSWORD = "password";
     private static final DockerImageName IMAGE_NAME = DockerImageName.parse("mysql:8.0.33");


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
유저 api를 구현했습니다

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
- 유저 api를 구현했습니다.
  - 모든 api는 연결된 oauth 계정이 하나라는 가정 하에 구현했습니다.
  - 조회
    - 본인 정보 조회 api입니다.
  - 수정
    - 닉네임 및 프로필 이미지 수정 api입니다.
    - 프로필 이미지를 null로 변경할 수 있기에, null에 대한 처리는 따로 하지 않았습니다. 
  - 삭제
    - 유저와 연관된 auth provider를 삭제한 후, user는 soft delete처리하도록 구현했습니다.
    - soft delete를 위한 isDeleted 칼럼을 추가했습니다.
- BaseEntity에 CreateDate 어노테이션은 LocalDateTime밖에 지원하지 않아, PrePersist를 사용하는 방식으로 변경했습니다.
- 테스트 컨테이너 데이터베이스 이름을 수정했습니다.
- 회원탈퇴 구현을 위해 카카오 adminKey 환경변수가 추가됐습니다. 프론트측에서 전달받으면 추가하면 됩니다.
- 프로필 이미지 칼럼 이름 변경(profileImage -> profileImegeUrl), isDeleted 칼럼 추가로 db migration V3 파일 추가했습니다.

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->

#### 이슈 번호
<!-- 지라 이슈 넘버를 붙여주세요. -->
[YB-92]


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->

[YB-92]: https://yeobee.atlassian.net/browse/YB-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ