### PR TITLE
Feat/YB-153 지출 리스트에서 여행 전/중/후 분기처리 구현

### DIFF
--- a/src/main/java/com/example/yeobee/core/expense/application/ExpenseService.java
+++ b/src/main/java/com/example/yeobee/core/expense/application/ExpenseService.java
@@ -60,8 +60,15 @@ public class ExpenseService {
         if (request.pageIndex() == null || request.pageSize() == null || request.tripId() == null) {
             throw new BusinessException(ErrorCode.BAD_REQUEST);
         }
-        return expenseRepository.findByFilter(new ExpenseListFilter(request),
-                                              PageRequest.of(request.pageIndex(), request.pageSize()));
+        Trip trip = tripRepository.findById(request.tripId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.TRIP_NOT_FOUND));
+        return expenseRepository.findByFilter(
+            new ExpenseListFilter(trip,
+                                  request.expenseType(),
+                                  request.payedAt(),
+                                  request.expenseMethod(),
+                                  request.currencyCode()),
+            PageRequest.of(request.pageIndex(), request.pageSize()));
     }
 
     private void createOrUpdateExpense(Expense expense, CreateOrUpdateExpenseDto dto, Long userId) {

--- a/src/main/java/com/example/yeobee/core/expense/dto/request/ExpenseListFilter.java
+++ b/src/main/java/com/example/yeobee/core/expense/dto/request/ExpenseListFilter.java
@@ -2,16 +2,10 @@ package com.example.yeobee.core.expense.dto.request;
 
 import com.example.yeobee.core.expense.domain.ExpenseMethod;
 import com.example.yeobee.core.expense.domain.ExpenseType;
+import com.example.yeobee.core.trip.domain.Trip;
 import java.time.LocalDate;
 
-public record ExpenseListFilter(Long tripId, ExpenseType expenseType, LocalDate payedAt,
+public record ExpenseListFilter(Trip trip, ExpenseType expenseType, LocalDate payedAt,
                                 ExpenseMethod expenseMethod, String currencyCode) {
 
-    public ExpenseListFilter(ExpenseListRetrieveRequestDto request) {
-        this(request.tripId(),
-             request.expenseType(),
-             request.payedAt(),
-             request.expenseMethod(),
-             request.currencyCode());
-    }
 }


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
지출 리스트에서 여행 전 / 중 / 후 분기처리를 구현했습니다.
#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
- api 변경 사항
  - GET /v1/expenses
    - 인자로 받은 payedAt이 여행 전이라면 payedAt 이전 지출내역 전부, 여행 후라면 payedAt 이후 지출내역 전부 반환합니다.
    - spec 자체 변경 사항은 없습니다.
  - 등록, 수정시 spec 변경사항은 없습니다. 날짜가 여행 하루 이전이 아니더라도 여행 전 리스트에 반환됩니다. 
##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->

#### 이슈 번호
<!-- 지라 이슈 넘버를 붙여주세요. -->
[YB-153]


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->

[YB-153]: https://yeobee.atlassian.net/browse/YB-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ